### PR TITLE
Feature to export transcriptions to JSON or CSV with time Stamps. 

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -35,7 +35,8 @@ import matplotlib
 matplotlib.use("TkAgg")
 import matplotlib.pyplot as plt
 import seaborn as sns
-
+import json
+import csv
 # Suppress FP16 warning
 warnings.filterwarnings("ignore", message="FP16 is not supported on CPU; using FP32 instead")
 

--- a/ui.py
+++ b/ui.py
@@ -710,6 +710,51 @@ def process_batch_transcription(filepaths):
     except Exception as e:
         messagebox.showerror("Error", f"Batch transcription failed: {e}")
 
+def export_transcription():
+    """
+    Exports the current transcription segments (from transcriber.segments_with_confidence)
+    to JSON or CSV with time stamps.
+    """
+    # Check if transcription data is available
+    if not hasattr(transcriber, "segments_with_confidence") or not transcriber.segments_with_confidence:
+        messagebox.showwarning("Export Error", "No transcription data available to export.")
+        return
+
+    # Ask the user to select format (Yes = JSON, No = CSV)
+    fmt_choice = messagebox.askquestion("Select Format", "Export as JSON? (Select 'No' for CSV)")
+    export_format = "json" if fmt_choice.lower() == "yes" else "csv"
+    file_extension = ".json" if export_format == "json" else ".csv"
+
+    # Open a file save dialog
+    file_path = filedialog.asksaveasfilename(
+        defaultextension=file_extension,
+        filetypes=[("JSON Files", "*.json")] if export_format == "json" else [("CSV Files", "*.csv")],
+        title="Save Transcription Export"
+    )
+    if not file_path:
+        return  # User cancelled
+
+    try:
+        data = transcriber.segments_with_confidence  # List of dictionaries with transcription details
+        if export_format == "json":
+            with open(file_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=4)
+        else:
+            with open(file_path, "w", newline="", encoding="utf-8") as csvfile:
+                fieldnames = ["timestamp", "text", "confidence"]
+                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+                writer.writeheader()
+                for segment in data:
+                    writer.writerow({
+                        "timestamp": segment.get("timestamp", ""),
+                        "text": segment.get("text", ""),
+                        "confidence": segment.get("confidence", "")
+                    })
+        messagebox.showinfo("Export Success", f"Transcription exported successfully to {file_path}")
+    except Exception as e:
+        messagebox.showerror("Export Error", f"Failed to export transcription: {e}")
+
+
 # Create a new horizontal frame
 main_frame = tk.Frame(root, bg="#2b2b2b")
 main_frame.pack(fill=tk.X, padx=10, pady=5)

--- a/ui.py
+++ b/ui.py
@@ -767,6 +767,20 @@ waveform_frame.pack(in_=main_frame, side=tk.RIGHT, padx=5)
 
 visualizer = WaveformVisualizer(waveform_frame)
 
+# Export Transcription Button
+export_button = tk.Button(
+    waveform_frame,
+    text="Export Transcription",
+    command=export_transcription,
+    bg="#008CBA",
+    fg="white",
+    font=("Helvetica", 12, "bold"),
+    bd=3, width=20,
+    height= 1,
+    relief=tk.RAISED
+)
+export_button.pack(pady=3)
+
 # Create log box
 log_box = tk.Text(button_container, height=8, width=60, wrap=tk.WORD, state=tk.DISABLED, bg="#333333", fg="white", font=("Helvetica", 10))
 log_box.pack(pady=5)


### PR DESCRIPTION
Closes : #70 
### **_Title: Implement Export Transcription Feature (JSON/CSV)_**

 ## Description:

This PR adds a new export functionality that enables users to export their transcription data (including timestamps, text, and confidence scores) to either JSON or CSV format. When the user clicks the new "Export Transcription" button, a dialog appears asking which format to use and then a file save dialog appears for the user to specify the file name and location. The feature operates on the transcription data stored in transcriber.segments_with_confidence and handles error cases (e.g., if no transcription is available, or if file saving fails).

## Changes Made:

- UI Changes (ui.py):
- Added an export_transcription() function that:
- Checks if transcription data is available.
- Prompts the user to select JSON or CSV export format.
- Opens a file save dialog and exports the transcription data in the selected format.
- Provides success or error notifications via message boxes.
- Added an "Export Transcription" button to the button frame (e.g., around line 535) that calls export_transcription().

<br>
 **

> Note : @CowTheGreat  Please review the changes and let me know if any modifications are required. Thanks!

**